### PR TITLE
Refactor alias and facade name so they don't collide with DataDog NS

### DIFF
--- a/src/DataDogFacade.php
+++ b/src/DataDogFacade.php
@@ -13,6 +13,6 @@ class DataDogFacade extends Facade
 	 */
 	protected static function getFacadeAccessor()
 	{
-		return 'DataDog';
+		return 'LaravelDataDog';
 	}
 }

--- a/src/DataDogMiddleware.php
+++ b/src/DataDogMiddleware.php
@@ -4,7 +4,7 @@ namespace MikeGarde\LaravelDataDogBatched;
 
 use Auth;
 use Closure;
-use DataDog;
+use LaravelDataDog;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -18,7 +18,7 @@ class DataDogMiddleware
 	 */
 	public function handle($request, Closure $next)
 	{
-		DataDog::startTime();
+		LaravelDataDog::startTime();
 
 		return $next($request);
 	}
@@ -75,9 +75,9 @@ class DataDogMiddleware
 			$tags['status'] = $response->status();
 		}
 
-		DataDog::set('uniques', $user);
-		DataDog::increment('request', config('datadog.sampleRate'), $tags);
-		DataDog::recordTiming('timing', config('datadog.sampleRate'), $tags);
-		DataDog::flush();
+		LaravelDataDog::set('uniques', $user);
+		LaravelDataDog::increment('request', config('datadog.sampleRate'), $tags);
+		LaravelDataDog::recordTiming('timing', config('datadog.sampleRate'), $tags);
+		LaravelDataDog::flush();
 	}
 }

--- a/src/DataDogServiceProvider.php
+++ b/src/DataDogServiceProvider.php
@@ -18,7 +18,7 @@ class DataDogServiceProvider extends ServiceProvider
 		$this->publishes(
 			[__DIR__ . '/../config/datadog.php' => config_path('datadog.php')],
 			'datadog-config');
-		$this->app->bind('DataDog', DataDogHelper::class);
+		$this->app->bind('LaravelDataDog', DataDogHelper::class);
 	}
 
 	/**
@@ -30,7 +30,7 @@ class DataDogServiceProvider extends ServiceProvider
 	{
 		$this->mergeConfigFrom(__DIR__ . '/../config/datadog.php', 'datadog');
 
-		$this->app->singleton('DataDog', function () {
+		$this->app->singleton('LaravelDataDog', function () {
 
 			return new \MikeGarde\LaravelDataDogBatched\DataDogHelper([
 				'host'                 => config('datadog.statsd_server'),

--- a/src/DoctrineFileLogger.php
+++ b/src/DoctrineFileLogger.php
@@ -2,7 +2,7 @@
 
 namespace MikeGarde\LaravelDataDogBatched;
 
-use DataDog;
+use LaravelDataDog;
 use Doctrine\DBAL\Logging\SQLLogger;
 use Psr\Log\LoggerInterface as Log;
 
@@ -75,13 +75,13 @@ class DoctrineFileLogger implements SQLLogger
 			$tag['route'] = $route;
 		}
 
-		DataDog::increment('sql', config('datadog.sampleRate'), $tag);
-		DataDog::microtiming('sql.timing', $this->getExecutionTime(), config('datadog.sampleRate'), $tag);
+		LaravelDataDog::increment('sql', config('datadog.sampleRate'), $tag);
+		LaravelDataDog::microtiming('sql.timing', $this->getExecutionTime(), config('datadog.sampleRate'), $tag);
 
 		// Some users may enable DataDog on Workers, if so lets periodically flush the buffer to DataDog
 		if (rand(1,100) <= 5)
 		{
-			DataDog::flush();
+			LaravelDataDog::flush();
 		}
 	}
 


### PR DESCRIPTION
Using a facade (`use DataDog;`) in a laravel application causes a namespace collision that attempts to call methods statically on DataDog ns class rather than loading DataDogHelper and invoking a dynamic method magically